### PR TITLE
feat: swap slides based on drag movement

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Props
 | `infinite`                      | `boolean`              | no           | `false`       |
 | `keyboardControl`               | `boolean`              | no           | `false`       |
 | `resetCurrentOnResize`          | `boolean`              | no           | `true`        |
+| `swapOnDragMoveEnd`             | `boolean`              | no           | `true`        |
 | `autoplayIntervalMs`            | `number`               | no           | `0`           |
 | `autoplayDirection`             | `string`               | no           | `'ltr'`       |
 | `offset`                        | `number` or `function` | no           | `0`           |
@@ -261,6 +262,19 @@ Default: `true`
 
 If `true`, carousel will re-render with the current state after the window has
 been resized. This operation is debounced by 200ms.
+
+#### `swapOnDragMoveEnd`
+
+Type: `boolean`
+
+Default: `true`
+
+If `true`, the carousel will change the current slide, to an adjacent one,
+based on the direction of the drag movement.
+Although, if the drag is enough to change the current slide by itself, it will
+respect that behaviour. 
+
+*Notes: Only works if the `draggable` prop is set as `true`.*
 
 #### `autoplayIntervalMs`
 

--- a/demo/pages/index.js
+++ b/demo/pages/index.js
@@ -24,6 +24,7 @@ const carouselProps = [
         ['infinite', 'checkbox'],
         ['keyboardControl', 'checkbox'],
         ['resetCurrentOnResize', 'checkbox'],
+        ['swapOnDragMoveEnd', 'checkbox'],
     ],
     [
         ['autoplayIntervalMs', 'number'],
@@ -122,6 +123,7 @@ const PropSetter = ({ children }) => {
             infinite: false,
             keyboardControl: false,
             resetCurrentOnResize: true,
+            swapOnDragMoveEnd: true,
             autoplayIntervalMs: 0,
             autoplayDirection: 'ltr',
             slideSnapDuration: 150,


### PR DESCRIPTION
**The Problem**

In some cases , the drag movement wouldn't be enough to change the current slide. This created a bounce back effect even though the user was expecting the slide to change to an adjacent one.

**The Solution**

We are now seeing the direction of the drag movement and based on that we change the slide to the previous/next one based on it.

Although, if the drag movement is enough to change the current slide, we respect that and we keep the original behavior.

This is now the default behavior but can be set on and off with a prop: `swapOnDragMoveEnd`
