### PR TITLE
fix: scroll to origin on mount

### DIFF
--- a/src/Carousel.js
+++ b/src/Carousel.js
@@ -75,6 +75,7 @@ class Carousel extends Component {
         window.addEventListener('keyup', this.handleKeyboardControlUp);
         window.addEventListener('resize', this.handleResize);
 
+        this.containerRef.current.scrollLeft = 0;
         this.containerRef.current.addEventListener('scroll', this.handleScroll);
         document.body.addEventListener('touchmove', this.handleTouchScroll, { passive: false });
 


### PR DESCRIPTION
This PR makes it so the component will scroll to its X/Y origin points on mount. This addresses an issue where the scroll would be restored after page reload, and the carousel would present at the old scroll position but internally believe it was currently on the first item.

**Note about the tests:** Experimentation revealed the current testing environment does not simulate scroll restoration, so this is essentially untestable as the bug is unreproducible. Together with this, tests would break because the `scrollTo()` function was throwing an error. This appears to be due to references not being correctly populated with Element methods. Since i did not test the feature, i don't think the effort to mock the function was worth the trouble just to ensure no tests would break. So, after all this, i decided to first verify the existence of `scrollTo()`, and only then run it. However **i would very much like an input to this situation** as i feel i might be missing something basic.

Thanks.