### PR TITLE
feat: add slidecount arg to renderarrows

### DIFF
--- a/src/Carousel.js
+++ b/src/Carousel.js
@@ -189,6 +189,7 @@ class Carousel extends Component {
                 current,
                 animating,
                 dragging,
+                slideCount,
             });
         }
 


### PR DESCRIPTION
PR for [Provide convience `slideCount` arg in `renderArrows` method](https://github.com/moxystudio/react-carousel/issues/14).

Adds `slideCount` to args passed to `renderArrows` method.

Thanks.