### PR TITLE
fix: reset autoplay when current changes

### DIFF
--- a/src/Carousel.js
+++ b/src/Carousel.js
@@ -97,6 +97,7 @@ class Carousel extends Component {
         const { current } = this.props;
 
         if (typeof current === 'number' && prevProps.current !== current) {
+            this.setupAutoplay();
             this.setCurrent(current);
         }
     }
@@ -150,7 +151,7 @@ class Carousel extends Component {
                             [modifierDraggableClassName]: draggable,
                             [modifierDraggingClassName]: dragging,
                         }, sliderClassName) }
-                        style={ { paddingLeft: offset, paddingRight: offset } }
+                        style={ offset > 0 ? { paddingLeft: offset, paddingRight: offset } : { } }
                         onDragStart={ this.handleSliderOnDragStart }
                         onMouseDown={ this.handleSliderMouseDown }
                         onMouseMove={ this.handleSliderMouseMove }
@@ -540,7 +541,6 @@ class Carousel extends Component {
 
         ev.stopPropagation();
 
-        this.setupAutoplay();
         this.setCurrent(slideIndex);
     };
 
@@ -601,8 +601,10 @@ class Carousel extends Component {
 
     // ------------------------------------------------------------------------ Resize events handlers
     handleResize = () => {
-        this.debouncedResize.cancel();
-        this.debouncedResize();
+        if (this.props.resetCurrentOnResize) {
+            this.debouncedResize.cancel();
+            this.debouncedResize();
+        }
     };
 }
 


### PR DESCRIPTION
This PR has the following fixes:

- Resets autoplay every time the current (slide) changes. This is particularly important when controlling the state externally;  
- Only adds the inline style when the offset is greater than 0. By doing this we make it easier to manipulate it with CSS;
- Adds a missing validation for the `resetCurrentOnResize` prop.
