### PR TITLE
feat: add source parameter to afterChange and beforeChange callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ Default: `() => {}`
 
 Callback function that is called before a slide change happens.
 
-Its signature is `({ current: number, next: number }) => void`
+Its signature is `({ current: number, next: number, source: 'user' | 'autoplay' }) => void`
 
 #### `afterChange`
 
@@ -409,7 +409,7 @@ Default: `() => {}`
 Callback function that is called after a slide change happens. Function is only
 called after transitions have ended and internal state is updated.
 
-Its signature is `({ previous: number, current: number }) => void`
+Its signature is `({ previous: number, current: number, source: 'user' | 'autoplay' }) => void`
 
 #### `renderArrows`
 

--- a/src/Carousel.js
+++ b/src/Carousel.js
@@ -278,10 +278,10 @@ class Carousel extends Component {
 
                 switch (autoplayDirection) {
                 case 'ltr':
-                    this.handleNext();
+                    this.handleNext({ source: 'autoplay' });
                     break;
                 case 'rtl':
-                    this.handlePrev();
+                    this.handlePrev({ source: 'autoplay' });
                     break;
                 default:
                     break;
@@ -339,8 +339,8 @@ class Carousel extends Component {
         return closestChildIndex;
     };
 
-    setCurrent = (i, options = { snap: false }) => {
-        const { snap } = options;
+    setCurrent = (i, options = {}) => {
+        const { snap = false, source = 'user' } = options;
         const { current } = this.state;
         const {
             slideSnapDuration,
@@ -356,7 +356,7 @@ class Carousel extends Component {
         this.setState({ animating: true });
 
         if (!snap) {
-            this.props.beforeChange({ current, next: i });
+            this.props.beforeChange({ current, next: i, source });
         }
 
         return animateProperty({
@@ -373,7 +373,7 @@ class Carousel extends Component {
             })
             .then(() => {
                 if (!snap) {
-                    this.props.afterChange({ previous: current, current: i });
+                    this.props.afterChange({ previous: current, current: i, source });
                 }
             });
     };
@@ -385,10 +385,10 @@ class Carousel extends Component {
         const current = this.calculateCurrent();
         const shouldNotify = previous !== current;
 
-        shouldNotify && this.props.beforeChange({ current: previous, next: current });
+        shouldNotify && this.props.beforeChange({ current: previous, next: current, source: 'user' });
 
         return this.setStateAsync({ current })
-            .then(() => shouldNotify && this.props.afterChange({ previous, current }));
+            .then(() => shouldNotify && this.props.afterChange({ previous, current, source: 'user' }));
     };
 
     shouldAllowCrossAxisScrolling = (ev) => {
@@ -445,20 +445,22 @@ class Carousel extends Component {
 
     // ------------------------------------------------------------------------ Arrow events handlers
 
-    handleNext = () => {
+    handleNext = (options = {}) => {
+        const { source = 'user' } = options;
         const { current, slideCount } = this.state;
 
         if (current === slideCount - 1 && !this.props.infinite) { return; }
 
-        return this.setCurrent((this.state.current + 1) % this.state.slideCount);
+        return this.setCurrent((this.state.current + 1) % this.state.slideCount, { source });
     };
 
-    handlePrev = () => {
+    handlePrev = (options = {}) => {
+        const { source = 'user' } = options;
         const { current } = this.state;
 
         if (current === 0 && !this.props.infinite) { return; }
 
-        return this.setCurrent(this.state.current === 0 ? this.state.slideCount - 1 : this.state.current - 1);
+        return this.setCurrent(this.state.current === 0 ? this.state.slideCount - 1 : this.state.current - 1, { source });
     };
 
     // ------------------------------------------------------------------------ Keyboard events handlers

--- a/src/Carousel.test.js
+++ b/src/Carousel.test.js
@@ -71,16 +71,16 @@ describe('Carousel', () => {
 
         // Change from first to  third slide
         fireEvent.mouseUp(slide(container, 2));
-        await wait(() => expect(props.beforeChange).toHaveBeenNthCalledWith(1, { current: 0, next: 2 }));
-        await wait(() => expect(props.afterChange).toHaveBeenNthCalledWith(1, { previous: 0, current: 2 }));
+        await wait(() => expect(props.beforeChange).toHaveBeenNthCalledWith(1, { current: 0, next: 2, source: 'user' }));
+        await wait(() => expect(props.afterChange).toHaveBeenNthCalledWith(1, { previous: 0, current: 2, source: 'user' }));
 
         expect(container.querySelectorAll('.rc-slide.-current')).toHaveLength(1);
         expect(slide(container, 2).className).toContain('-current');
 
         // Change from third to sixth slide
         fireEvent.mouseUp(slide(container, 5));
-        await wait(() => expect(props.beforeChange).toHaveBeenNthCalledWith(2, { current: 2, next: 5 }));
-        await wait(() => expect(props.afterChange).toHaveBeenNthCalledWith(2, { previous: 2, current: 5 }));
+        await wait(() => expect(props.beforeChange).toHaveBeenNthCalledWith(2, { current: 2, next: 5, source: 'user' }));
+        await wait(() => expect(props.afterChange).toHaveBeenNthCalledWith(2, { previous: 2, current: 5, source: 'user' }));
 
         expect(container.querySelectorAll('.rc-slide.-current')).toHaveLength(1);
         expect(slide(container, 5).className).toContain('-current');
@@ -112,16 +112,16 @@ describe('Carousel', () => {
         await wait(() => expect(next.disabled).toBe(false));
 
         fireEvent.click(next);
-        await wait(() => expect(props.beforeChange).toHaveBeenNthCalledWith(1, { current: 0, next: 1 }));
-        await wait(() => expect(props.afterChange).toHaveBeenNthCalledWith(1, { previous: 0, current: 1 }));
+        await wait(() => expect(props.beforeChange).toHaveBeenNthCalledWith(1, { current: 0, next: 1, source: 'user' }));
+        await wait(() => expect(props.afterChange).toHaveBeenNthCalledWith(1, { previous: 0, current: 1, source: 'user' }));
 
         fireEvent.click(next);
-        await wait(() => expect(props.beforeChange).toHaveBeenNthCalledWith(2, { current: 1, next: 2 }));
-        await wait(() => expect(props.afterChange).toHaveBeenNthCalledWith(2, { previous: 1, current: 2 }));
+        await wait(() => expect(props.beforeChange).toHaveBeenNthCalledWith(2, { current: 1, next: 2, source: 'user' }));
+        await wait(() => expect(props.afterChange).toHaveBeenNthCalledWith(2, { previous: 1, current: 2, source: 'user' }));
 
         fireEvent.click(prev);
-        await wait(() => expect(props.beforeChange).toHaveBeenNthCalledWith(3, { current: 2, next: 1 }));
-        await wait(() => expect(props.afterChange).toHaveBeenNthCalledWith(3, { previous: 2, current: 1 }));
+        await wait(() => expect(props.beforeChange).toHaveBeenNthCalledWith(3, { current: 2, next: 1, source: 'user' }));
+        await wait(() => expect(props.afterChange).toHaveBeenNthCalledWith(3, { previous: 2, current: 1, source: 'user' }));
     });
 
     it('should not navigate using keyboard if keyboardControl prop is false', async () => {
@@ -225,6 +225,23 @@ describe('Carousel', () => {
         expect(slide(0).className).toContain('-current');
         await sleep(100);
         expect(slide(0).className).toContain('-current');
+    });
+
+    it('should autoplay and return the source correctly', async () => {
+        const props = {
+            slideTransitionDuration: 1,
+            slideSnapDuration: 1,
+            autoplayIntervalMs: 1,
+            beforeChange: jest.fn(),
+            afterChange: jest.fn(),
+        };
+
+        render(<Carousel { ...props }>{renderSlides()}</Carousel>);
+
+        Array.from({ length: 9 }).forEach(async (_, i) => {
+            await wait(() => expect(props.beforeChange).toHaveBeenNthCalledWith(1, { current: i, next: i + 1, source: 'autoplay' }));
+            await wait(() => expect(props.afterChange).toHaveBeenNthCalledWith(1, { previous: i, current: i + 1, source: 'autoplay' }));
+        });
     });
 
     [


### PR DESCRIPTION
This PR adds a new parameter `source` to `afterChange` and `beforeChange` callbacks, so we know if the update was either caused by the `autoplay` or by an `user` interaction.